### PR TITLE
feat: PCM Custom Relationship endpoint

### DIFF
--- a/src/endpoints/pcm-custom-relationship.js
+++ b/src/endpoints/pcm-custom-relationship.js
@@ -1,0 +1,70 @@
+import RequestFactory from '../factories/request'
+
+class PCMCustomRelationshipEndpoint {
+  constructor(endpoint) {
+    const config = { ...endpoint }
+    this.request = new RequestFactory(config)
+    config.version = 'pcm'
+    this.endpoint = 'custom-relationships'
+  }
+
+  All(productId) {
+    return this.request.send(`products/${productId}/${this.endpoint}`, 'GET')
+  }
+
+  AttachCustomRelationship(productId, body) {
+    return this.request.send(
+      `products/${productId}/${this.endpoint}`,
+      'POST',
+      body
+    )
+  }
+
+  DetachCustomRelationship(productId, body) {
+    return this.request.send(
+      `products/${productId}/${this.endpoint}`,
+      'DELETE',
+      body
+    )
+  }
+
+  AssociateProductsToCustomRelationship(
+    productId,
+    customRelationshipSlug,
+    productsToAssociate
+  ) {
+    return this.request.send(
+      `products/${productId}/${this.endpoint}/${customRelationshipSlug}`,
+      'POST',
+      productsToAssociate
+    )
+  }
+
+  DissociateProductsFromCustomRelationship(
+    productId,
+    customRelationshipSlug,
+    productsToDissociate
+  ) {
+    return this.request.send(
+      `products/${productId}/${this.endpoint}/${customRelationshipSlug}`,
+      'DELETE',
+      productsToDissociate
+    )
+  }
+
+  GetProductsForCustomRelationship(productId, customRelationshipSlug) {
+    return this.request.send(
+      `products/${productId}/${this.endpoint}/${customRelationshipSlug}/products`,
+      'GET'
+    )
+  }
+
+  GetProductIdsForCustomRelationship(productId, customRelationshipSlug) {
+    return this.request.send(
+      `products/${productId}/${this.endpoint}/${customRelationshipSlug}`,
+      'GET'
+    )
+  }
+}
+
+export default PCMCustomRelationshipEndpoint

--- a/src/endpoints/pcm.js
+++ b/src/endpoints/pcm.js
@@ -5,6 +5,7 @@ import PCMTemplateRelationshipEndpoint from './pcm-template-relationship'
 import PCMMainImageRelationshipEndpoint from './pcm-main-image-relationship'
 import { buildURL } from '../utils/helpers'
 import PCMJobs from './pcm-jobs'
+import PCMCustomRelationshipEndpoint from './pcm-custom-relationship'
 
 class PCMEndpoint extends CRUDExtend {
   constructor(endpoint) {
@@ -16,6 +17,7 @@ class PCMEndpoint extends CRUDExtend {
     this.VariationsRelationships = new PCMVariationsRelationshipEndpoint(config)
     this.TemplateRelationships = new PCMTemplateRelationshipEndpoint(config)
     this.MainImageRelationships = new PCMMainImageRelationshipEndpoint(config)
+    this.CustomRelationships = new PCMCustomRelationshipEndpoint(config)
     this.Jobs = new PCMJobs(config)
 
     this.endpoint = 'products'

--- a/src/types/pcm-custom-relationship.ts
+++ b/src/types/pcm-custom-relationship.ts
@@ -1,0 +1,119 @@
+/**
+ * Product Custom Relationships
+ */
+import { Identifiable, ResourceList } from './core'
+import {
+  CustomRelationshipsListResponse
+} from './custom-relationships'
+import { PcmProduct } from './pcm'
+
+export interface PcmProductEntry extends Identifiable {
+  type: 'product'
+}
+
+// TODO -- Entry type of attach/detach endpoint data array field
+export interface CustomRelationshipEntry {
+  type: 'custom-relationship'
+  slug: string
+}
+
+export interface PcmRelatedProductResponse<T> extends ResourceList<T> {
+  meta: {
+    results: {
+      total: number
+    }
+  }
+}
+
+export interface NonAssociatedProductEntry extends Identifiable {
+    details: string
+}
+
+export interface ProductAssociationResponse {
+  meta: {
+    associated_products: string[]
+    products_not_associated: NonAssociatedProductEntry[]
+    owner: 'organization' | 'store'
+    timestamps: {
+      created_at: string
+      updated_at: string
+    }
+  }
+}
+
+// TODO - Update attach/detach endpoint body types after api bug fix
+export interface PcmCustomRelationshipEndpoint {
+  endpoint: 'custom-relationships'
+
+  /**
+   * Get all of a product's custom relationships
+   * @param productId
+   */
+  All(productId: string): Promise<CustomRelationshipsListResponse>
+
+  /**
+   * Attach a custom relationship to a product
+   * @param productId
+   * @param body
+   */
+  AttachCustomRelationship(
+    productId: string,
+    body: CustomRelationshipEntry
+  ): Promise<CustomRelationshipsListResponse>
+
+  /**
+   * Detach a custom relationship from a product
+   * @param productId
+   * @param body
+   */
+  DetachCustomRelationship(
+    productId: string,
+    body: CustomRelationshipEntry[]
+  ): Promise<void>
+
+  /**
+   * Associate a product with other products under a custom relationship
+   * @param productId
+   * @param customRelationshipSlug
+   * @param productsToAssociate
+   * @returns
+   */
+  AssociateProductsToCustomRelationship(
+    productId: string,
+    customRelationshipSlug: string,
+    productsToAssociate: PcmProductEntry[]
+  ): Promise<ProductAssociationResponse>
+
+  /**
+   * Dissociate related products from a product under a custom relationship
+   * @param productId
+   * @param customRelationshipSlug
+   * @param productsToDissociate
+   */
+  DissociateProductsFromCustomRelationship(
+    productId: string,
+    customRelationshipSlug: string,
+    productsToDissociate: PcmProductEntry[]
+  ): Promise<void>
+
+  /**
+   * Get all related products of a product under a custom relationship
+   * @param productId
+   * @param customRelationshipSlug
+   */
+  GetProductsForCustomRelationship(
+    productId: string,
+    customRelationshipSlug: string
+  ): Promise<PcmRelatedProductResponse<PcmProduct>>
+
+  /**
+   * Get all IDs of a product's related products under a custom relationship
+   * @param productId
+   * @param customRelationshipSlug
+   *  TODO CHECK RETURN VALUE
+   */
+  GetProductIdsForCustomRelationship(
+    productId: string,
+    customRelationshipSlug: string
+  ): Promise<PcmRelatedProductResponse<PcmProductEntry>>
+}

--- a/src/types/pcm-custom-relationship.ts
+++ b/src/types/pcm-custom-relationship.ts
@@ -11,7 +11,6 @@ export interface PcmProductEntry extends Identifiable {
   type: 'product'
 }
 
-// TODO -- Entry type of attach/detach endpoint data array field
 export interface CustomRelationshipEntry {
   type: 'custom-relationship'
   slug: string
@@ -41,7 +40,6 @@ export interface ProductAssociationResponse {
   }
 }
 
-// TODO - Update attach/detach endpoint body types after api bug fix
 export interface PcmCustomRelationshipEndpoint {
   endpoint: 'custom-relationships'
 

--- a/src/types/pcm-custom-relationship.ts
+++ b/src/types/pcm-custom-relationship.ts
@@ -60,7 +60,7 @@ export interface PcmCustomRelationshipEndpoint {
   ): Promise<CustomRelationshipsListResponse>
 
   /**
-   * Detach a custom relationship from a product
+   * Detach one or multiple custom relationships from a product
    * @param productId
    * @param body
    */

--- a/src/types/pcm.d.ts
+++ b/src/types/pcm.d.ts
@@ -13,6 +13,7 @@ import { PcmFileRelationshipEndpoint } from './pcm-file-relationship'
 import { PcmTemplateRelationshipEndpoint } from './pcm-template-relationship'
 import { PcmVariationsRelationshipsEndpoint } from './pcm-variations-relationships'
 import { PcmMainImageRelationshipEndpoint } from './pcm-main-image-relationship'
+import { PcmCustomRelationshipEndpoint } from './pcm-custom-relationship'
 import { PcmJobBase, PcmJobsEndpoint } from './pcm-jobs'
 import { File } from './file'
 import { Locales } from './locales'
@@ -182,6 +183,7 @@ export interface PcmProductsEndpoint
   TemplateRelationships: PcmTemplateRelationshipEndpoint
   VariationsRelationships: PcmVariationsRelationshipsEndpoint
   MainImageRelationships: PcmMainImageRelationshipEndpoint
+  CustomRelationships: PcmCustomRelationshipEndpoint
   Jobs: PcmJobsEndpoint
 
   Limit(value: number): PcmProductsEndpoint


### PR DESCRIPTION
## Type

* ### Feature

## Description

- Add `PcmCustomRelationshipEndpoint` class and use it as a member of the `PCM` endpoint class

 As part of the newly added class, the following endpoint methods were added:

- Add endpoint method for attaching a custom relationship to a product (`AttachCustomRelationship`)
- Add endpoint for detaching a custom relationship from a product (`DetachCustomRelationship`)
- Add endpoint for fetching a product's attached custom relationships (`All`)
- Add endpoint for associating a product to another product under a custom relationship (`AssociateProductsToCustomRelationship`)
- Add endpoint for dissociating a product from another product under a custom relationship (`DissociateProductsFromCustomRelationship`)
- Add endpoint for fetching product IDs of a product's custom relationship (`GetProductIdsForCustomRelationship`)
- Add endpoint for fetching all related products (full data) of a product that are related under a custom relationship (`GetProductsForCustomRelationship`)

## Issues

Related ticket: https://gitlab.elasticpath.com/commerce-cloud/ncl-projects/paragon/team/-/issues/384

## Notes
- The request body data type of the attach / detach custom relationships to/from a product is incorrect currently. It will be fixed as soo as the API works as intended.