### PR TITLE
fix: return type of AttachCustomRelationshipToProduct method

### DIFF
--- a/src/types/pcm-custom-relationship.ts
+++ b/src/types/pcm-custom-relationship.ts
@@ -1,8 +1,9 @@
 /**
  * Product Custom Relationships
  */
-import { Identifiable, ResourceList } from './core'
+import { Identifiable, Resource, ResourceList } from './core'
 import {
+  CustomRelationship,
   CustomRelationshipsListResponse
 } from './custom-relationships'
 import { PcmProduct } from './pcm'
@@ -61,7 +62,7 @@ export interface PcmCustomRelationshipEndpoint {
   AttachCustomRelationship(
     productId: string,
     body: CustomRelationshipEntry
-  ): Promise<CustomRelationshipsListResponse>
+  ): Promise<Resource<CustomRelationship>>
 
   /**
    * Detach one or multiple custom relationships from a product


### PR DESCRIPTION
## Type

* ### Fix

## Description

- Fixed return type of AttachCustomRelationshipToProduct method to use the `Resource<CustomRelationship>` interface instead of `CustomRelationshipsListResponse` 
