### PR TITLE
feat: make description field optional

### DIFF
--- a/src/types/rule-promotions.ts
+++ b/src/types/rule-promotions.ts
@@ -53,7 +53,7 @@ export interface Condition {
 export interface RulePromotionBase {
   type: 'rule_promotion'
   name: string
-  description: string
+  description?: string
   enabled: boolean
   automatic?: boolean
   start: string


### PR DESCRIPTION
## Type

* ### Feature
  Implements a new feature

## Description
- update `description` restriction to be optional

## Notes

*Any additional notes.*
[[MT-17854] Make description field optional](https://gitlab.elasticpath.com/commerce-cloud/commerce-manager/-/merge_requests/2576) depends on the this PR