### PR TITLE
feat!: Custom relationship type updates

### DIFF
--- a/src/types/core.d.ts
+++ b/src/types/core.d.ts
@@ -115,3 +115,11 @@ export interface CrudQueryableResource<R, C, U, F, S, I>
 
   Link(url: string): Promise<Resource<R>>
 }
+
+export interface SimpleResourcePageResponse<T> extends ResourceList<T> {
+  meta: {
+    results: {
+      total: number
+    }
+  }
+}

--- a/src/types/pcm-custom-relationship.ts
+++ b/src/types/pcm-custom-relationship.ts
@@ -23,8 +23,8 @@ export interface NonAssociatedProductEntry extends Identifiable {
 
 export interface ProductAssociationResponse {
   meta: {
-    associated_products: string[]
-    products_not_associated: NonAssociatedProductEntry[]
+    associated_products?: string[]
+    products_not_associated?: NonAssociatedProductEntry[]
     owner: 'organization' | 'store'
     timestamps: {
       created_at: string

--- a/src/types/pcm-custom-relationship.ts
+++ b/src/types/pcm-custom-relationship.ts
@@ -1,7 +1,7 @@
 /**
  * Product Custom Relationships
  */
-import { Identifiable, Resource, ResourceList } from './core'
+import { Identifiable, SimpleResourcePageResponse } from './core'
 import {
   CustomRelationship,
   CustomRelationshipsListResponse
@@ -15,14 +15,6 @@ export interface PcmProductEntry extends Identifiable {
 export interface CustomRelationshipEntry {
   type: 'custom-relationship'
   slug: string
-}
-
-export interface PcmRelatedProductResponse<T> extends ResourceList<T> {
-  meta: {
-    results: {
-      total: number
-    }
-  }
 }
 
 export interface NonAssociatedProductEntry extends Identifiable {
@@ -61,8 +53,8 @@ export interface PcmCustomRelationshipEndpoint {
    */
   AttachCustomRelationship(
     productId: string,
-    body: CustomRelationshipEntry
-  ): Promise<Resource<CustomRelationship>>
+    body: CustomRelationshipEntry[]
+  ): Promise<SimpleResourcePageResponse<CustomRelationship>>
 
   /**
    * Detach one or multiple custom relationships from a product
@@ -107,7 +99,7 @@ export interface PcmCustomRelationshipEndpoint {
   GetProductsForCustomRelationship(
     productId: string,
     customRelationshipSlug: string
-  ): Promise<PcmRelatedProductResponse<PcmProduct>>
+  ): Promise<SimpleResourcePageResponse<PcmProduct>>
 
   /**
    * Get all IDs of a product's related products under a custom relationship
@@ -118,5 +110,5 @@ export interface PcmCustomRelationshipEndpoint {
   GetProductIdsForCustomRelationship(
     productId: string,
     customRelationshipSlug: string
-  ): Promise<PcmRelatedProductResponse<PcmProductEntry>>
+  ): Promise<SimpleResourcePageResponse<PcmProductEntry>>
 }

--- a/src/types/pcm.d.ts
+++ b/src/types/pcm.d.ts
@@ -99,9 +99,12 @@ type productType = 'standard' | 'parent' | 'child'| 'bundle'
 
 export interface PcmProduct extends Identifiable, PcmProductBase {
   meta: {
+    created_at: string
+    updated_at: string
     variation_matrix: { [key: string]: string } | {}
     owner?: 'organization' | 'store'
     product_types?: productType[]
+    custom_relationships?: string[]
   }
 }
 
@@ -118,6 +121,13 @@ export interface PcmProductRelationships {
     main_image?: {
       data: {
         id: string
+      }
+    }
+    custom_relationships?: {
+      data?: Array<unknown> | null
+      links?: {
+        [key: string]: string
+        self: string
       }
     }
   }


### PR DESCRIPTION
## Type

* ### Feature

## Description

BREAKING CHANGE:
- Updated `AttachCustomRelationship` method second argument to be an array
- Removed `PcmRelatedProductResponse` from . Instead, it was renamed to `SimpleResourcePageResponse` and moved to the `core.d.ts` file. Updated endpoint method usages.
- Updated `PcmProduct` and `PcmProductRelationships ` types to include new custom_relationship fields
- Fixed `ProductAssociationResponse ` to be in-line with the API