### PR TITLE
fix: MLI location update body nullable fields

### DIFF
--- a/src/types/mli-locations.d.ts
+++ b/src/types/mli-locations.d.ts
@@ -37,7 +37,16 @@ export interface Location extends Identifiable, LocationBase {}
 
 export interface CreateLocationBody extends LocationAttributes {}
 
-export interface UpdateLocationBody extends LocationAttributes {}
+export interface UpdateLocationBody
+  extends Omit<
+    LocationAttributes,
+    'external_ref' | 'description' | 'address' | 'geolocation'
+  > {
+  external_ref?: string | null
+  description?: string | null
+  address?: string[] | null[]
+  geolocation?: GeolocationDetails | null
+}
 
 /**
  * Location Endpoints


### PR DESCRIPTION
## Type

* ### Fix
  Fixes a bug

## Description

Make the MLI location update body fields nullable. It is necessary to pass null for fields that were present and have been deleted.

## Dependencies

*Other PRs or builds that this PR depends on.*

## Issues

*A list of issues closed by this PR.*

* Fixes #

## Notes

*Any additional notes.*
