### PR TITLE
feat: Add GetRelatedProducts endpoint method to shopper catalog endpoint class

### DIFF
--- a/src/endpoints/catalog.js
+++ b/src/endpoints/catalog.js
@@ -315,6 +315,31 @@ class Products extends ShopperCatalogProductsQuery {
       additionalHeaders
     )
   }
+
+  GetRelatedProducts({
+    productId,
+    customRelationshipSlug,
+    token = null,
+    additionalHeaders = null
+  }) {
+    const { limit, offset, filter, includes } = this
+
+    return this.request.send(
+      buildURL(`catalog/${this.endpoint}/${productId}/relationships/${customRelationshipSlug}/products`, {
+        limit,
+        offset,
+        filter,
+        includes
+      }),
+      'GET',
+      undefined,
+      token,
+      undefined,
+      false,
+      undefined,
+      additionalHeaders
+    )
+  }
 }
 
 class ShopperCatalogEndpoint extends ShopperCatalogQuery {

--- a/src/types/catalog.d.ts
+++ b/src/types/catalog.d.ts
@@ -167,6 +167,13 @@ export interface ShopperCatalogProductsEndpoint
     token?: string
     additionalHeaders?: ShopperCatalogAdditionalHeaders
   }): Promise<ShopperCatalogResourcePage<ProductResponse>>
+
+  GetRelatedProducts(options: {
+    productId: string
+    customRelationshipSlug: string
+    token?: string
+    additionalHeaders?: ShopperCatalogAdditionalHeaders
+  }): Promise<ShopperCatalogResourcePage<ProductResponse>>
 }
 
 export interface NodesShopperCatalogEndpoint


### PR DESCRIPTION
## Type

* ### Feature

## Description

- Add `GetRelatedProducts` to `ShopperCatalog.Products` endpoint class.

## Issues

- https://gitlab.elasticpath.com/commerce-cloud/ncl-projects/paragon/team/-/issues/383
