### PR TITLE
fix: MLI endpoint header

### DIFF
--- a/src/endpoints/multi-location-inventories.js
+++ b/src/endpoints/multi-location-inventories.js
@@ -5,11 +5,10 @@ import InventoryLocationsEndpoint from './mli-locations'
 class MultiLocationInventories {
   constructor(endpoint) {
     const config = { ...endpoint }
-    config.headers = {
-      ...config.headers,
-      'ep-inventories-multi-location': true
-    }
-    this.request = new RequestFactory(endpoint)
+
+    config.headers['ep-inventories-multi-location'] = true
+
+    this.request = new RequestFactory(config)
 
     this.Locations = new InventoryLocationsEndpoint(config)
 


### PR DESCRIPTION
## Type

* ### Fix
  Fixes a bug

## Description

I fixed the issue by updating `config.headers` directly instead of reassigning it. Reassigning created a new object, breaking the reference to the original `config`, which caused issues. The fix preserves the reference while adding the new header.

## Dependencies

*Other PRs or builds that this PR depends on.*

## Issues

*A list of issues closed by this PR.*

* Fixes #

## Notes

*Any additional notes.*
