### PR TITLE
fix: isolate MLI header to prevent unintended propagation

### DIFF
--- a/src/endpoints/multi-location-inventories.js
+++ b/src/endpoints/multi-location-inventories.js
@@ -6,7 +6,10 @@ class MultiLocationInventories {
   constructor(endpoint) {
     const config = { ...endpoint }
 
-    config.headers['ep-inventories-multi-location'] = true
+    config.headers = {
+      ...config.headers,
+      'ep-inventories-multi-location': true
+    }
 
     this.request = new RequestFactory(config)
 


### PR DESCRIPTION
## Type

* ### Fix
  Fixes a bug

## Description

Fixed config.headers to ensure 'ep-inventories-multi-location' is scoped to MLI requests only.

## Dependencies

*Other PRs or builds that this PR depends on.*

## Issues

*A list of issues closed by this PR.*

* Fixes #

## Notes

*Any additional notes.*
