### PR TITLE
feat: add optional promotion source type in order

### DIFF
--- a/src/types/order.d.ts
+++ b/src/types/order.d.ts
@@ -272,6 +272,7 @@ export interface OrderItem extends Identifiable, OrderItemBase {
       }
       id: string
       code: string
+      promotion_source?: string
     }
   ]
   components?: ProductComponents
@@ -285,6 +286,7 @@ export interface OrderItem extends Identifiable, OrderItemBase {
   catalog_source?: 'pim'
   custom_inputs?: Record<string, any>
   shipping_group_id?: string
+  promotion_source?: string
 }
 
 export type PurchasePaymentMethod = 'purchase'


### PR DESCRIPTION
## Type

* ### Feature
  Implements a new feature

## Description
- add new optional `promotion_source` field in order type

## Dependencies
- [[MR-2671]](https://gitlab.elasticpath.com/commerce-cloud/commerce-manager/-/merge_requests/2671) Order page UI improvements

