### PR TITLE
feat: support or in filter

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -96,12 +96,11 @@ function formatFilterString(type, filter) {
 
     if (Array.isArray(value)) {
       queryString = `${key},${value.join(',')}`
-    } else if (typeof value === 'object') {
-      queryString = Object.keys(value).map(
-        attr => `${key}.${attr},${value[attr]}`
-      )
+    } else if (typeof value === 'object' && value !== null) {
+      queryString = Object.keys(value)
+        .map(attr => `${key}.${attr},${value[attr]}`)
+        .join(':')
     }
-
     return `${type}(${queryString})`
   })
 
@@ -114,6 +113,15 @@ function formatQueryString(key, value) {
   }
 
   if (key === 'filter') {
+    if (value.or && Array.isArray(value.or)) {
+      const orQueries = value.or.map(filterGroup =>
+        Object.keys(filterGroup)
+          .map(filterType => formatFilterString(filterType, filterGroup[filterType]))
+          .join(':')
+      )
+      return `${key}=(${orQueries.join('|')})`
+    }
+
     const filterValues = Object.keys(value).map(filter =>
       formatFilterString(filter, value[filter])
     )

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -176,6 +176,21 @@ describe('Format filter string', () => {
 
     expect(res).to.equal('in(sku,prod12,prod34,prod56)')
   })
+
+  it('should handle multiple filters of the same type', () => {
+    const res = formatFilterString('eq', {
+      name: 'Code',
+      age: 'welcome10'
+    })
+    expect(res).to.equal('eq(name,Code):eq(age,welcome10)')
+  })
+
+  it('should handle nested object with multiple attributes', () => {
+    const res = formatFilterString('eq', {
+      price: { gt: '100', lt: '200' }
+    })
+    expect(res).to.equal('eq(price.gt,100:price.lt,200)')
+  })
 })
 
 describe('Format query string', () => {
@@ -197,6 +212,59 @@ describe('Format query string', () => {
     const res = formatQueryString('filter', { eq: { name: 'Test' } })
 
     expect(res).to.equal('filter=eq(name,Test)')
+  })
+
+  it('should handle multiple filter types', () => {
+    const res = formatQueryString('filter', {
+      eq: { name: 'sku-123' },
+      gt: { price: '100' }
+    })
+    expect(res).to.equal('filter=eq(name,sku-123):gt(price,100)')
+  })
+
+  it('should handle OR conditions in filters', () => {
+    const res = formatQueryString('filter', {
+      or: [{ eq: { category: 'hoodies' } }, { eq: { category: 't-shirts' } }]
+    })
+    expect(res).to.equal('filter=(eq(category,hoodies)|eq(category,t-shirts))')
+  })
+
+  it('should handle complex OR conditions with multiple filter types', () => {
+    const res = formatQueryString('filter', {
+      or: [
+        {
+          eq: { category: 'hoodies' },
+          gt: { price: '10' }
+        },
+        {
+          eq: { category: 't-shirts' },
+          lt: { price: '20' }
+        }
+      ]
+    })
+    expect(res).to.equal(
+      'filter=(eq(category,hoodies):gt(price,10)|eq(category,t-shirts):lt(price,20))'
+    )
+  })
+
+  it('should handle OR conditions with datetime comparisons', () => {
+    const res = formatQueryString('filter', {
+      or: [
+        {
+          le: { start: '"2025-01-29T23:31:08.400Z"' },
+          gt: { end: '"2025-01-29T23:31:08.400Z"' }
+        },
+        {
+          gt: {
+            start: '"2025-01-29T23:31:08.400Z"',
+            end: '"2025-01-29T23:31:08.400Z"'
+          }
+        }
+      ]
+    })
+    expect(res).to.equal(
+      'filter=(le(start,2025-01-29T23:31:08.400Z):gt(end,2025-01-29T23:31:08.400Z)|gt(start,2025-01-29T23:31:08.400Z):gt(end,2025-01-29T23:31:08.400Z))'
+    )
   })
 })
 


### PR DESCRIPTION
## Type

* ### Feature
  Implements a new feature

## Description
- support `OR` in filter
- add new tests

## Dependencies
- [[MR-2910] Status filter multi select](https://gitlab.elasticpath.com/commerce-cloud/commerce-manager/-/merge_requests/2910)
