### PR TITLE
chore: bump actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
           yarn install
           yarn rollup
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ github.event.repository.name }}-${{ github.sha }}-${{ github.run_id }}-bundles
           path: dist
@@ -78,7 +78,7 @@ jobs:
           yarn install
           yarn test-output
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ github.event.repository.name }}-${{ github.sha }}-${{ github.run_id }}-${{ github.job }}-results
           path: test-results


### PR DESCRIPTION
## Type

* ### Chore
  Changes to the build process or auxiliary tools and libraries such as documentation generation  

## Description
 - bump actions/upload-artifact to v4
    - https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
