### PR TITLE
chore: bump actions/download-artifact from v3 to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
           node-version: '20'
           cache: 'yarn'
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ github.event.repository.name }}-${{ github.sha }}-${{ github.run_id }}-bundles
           path: dist


### PR DESCRIPTION
## Type

* ### Chore
  Changes to the build process or auxiliary tools and libraries such as documentation generation  

## Description
- bump actions/download-artifact from v3 to v4
![image](https://github.com/user-attachments/assets/214740fa-43bf-4b88-be5c-5ef4ebe00762)

