### PR TITLE
fix: make legal name in accounts optional

### DIFF
--- a/src/types/accounts.d.ts
+++ b/src/types/accounts.d.ts
@@ -40,7 +40,7 @@ export interface Account extends AccountBase, Identifiable {
 export interface AccountBase {
   type: string
   name: string
-  legal_name: string
+  legal_name?: string
   registration_id?: string
   parent_id?: string
   external_ref?: string


### PR DESCRIPTION
## Type

* ### Fix
  Fixes a bug

## Description
- make legal name field in accounts optional 

## Dependencies
[[MR-2949] Make legal name and registration id optional](https://gitlab.elasticpath.com/commerce-cloud/commerce-manager/-/merge_requests/2949)