### PR TITLE
[MT-19489] Add cart snapshot_date and order order_number optional fields.

### DIFF
--- a/src/types/cart.d.ts
+++ b/src/types/cart.d.ts
@@ -71,6 +71,7 @@ export interface Cart {
   discount_settings: {
     custom_discounts_enabled: boolean
   }
+  snapshot_date?: string
 }
 
 export interface CartItemBase {

--- a/src/types/order.d.ts
+++ b/src/types/order.d.ts
@@ -74,6 +74,7 @@ export interface OrderBase {
   shipping_address: OrderShippingAddress
   billing_address: OrderBillingAddress
   external_ref?: string
+  order_number?: string
 }
 
 export interface Order extends Identifiable, OrderBase {


### PR DESCRIPTION
## Type

* ### Feature
  * Add cart `snapshot_date` as an optional field
  * Add order `order_number` as an optional field

## Description

Adds cart `snapshot_date` and order `order_number` fields to support further development.

## Notes
Related to https://gitlab.elasticpath.com/commerce-cloud/commerce-manager/-/merge_requests/3141.
