### PR TITLE
chore: pin node version to 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,5 +113,8 @@
       "prettier --write",
       "git add"
     ]
+  },
+  "volta": {
+    "node": "16.20.2"
   }
 }


### PR DESCRIPTION
## Type
* ### Chore
  Changes to the build process or auxiliary tools and libraries such as documentation generation  

## Description
This pins the node version to the same one [that runs in CI](https://github.com/elasticpath/js-sdk/actions/runs/15035231947/job/42255643436)
<img width="544" alt="image" src="https://github.com/user-attachments/assets/7542ad7c-60e4-46e4-b215-3889ed3e7661" />
