### PR TITLE
feat: add support for auto add in rule promotion

### DIFF
--- a/src/types/rule-promotions.ts
+++ b/src/types/rule-promotions.ts
@@ -18,6 +18,8 @@ export interface ActionLimitation {
   items?: {
     max_items?: number
     price_strategy?: string
+    auto_add?: boolean
+    show_suggestions?: boolean
   }
 }
 


### PR DESCRIPTION
## Type

* ### Feature
  Implements a new feature

## Description
- add support for auto_add and show_suggestions in rule promotion

## Dependencies
- [[MT-21403] Add auto add & upsell suggestion in bxgy](https://gitlab.elasticpath.com/commerce-cloud/commerce-manager/-/merge_requests/3226)

