### PR TITLE
Feat: add support for account tags

### DIFF
--- a/src/endpoints/account-tags.js
+++ b/src/endpoints/account-tags.js
@@ -1,0 +1,50 @@
+import BaseExtend from '../extends/base'
+import { buildURL } from '../utils/helpers'
+
+class AccountTagsEndpoint extends BaseExtend {
+  Create(body, token = null) {
+    return this.request.send(`account-tags`, 'POST', body, token, this)
+  }
+
+  All(token = null) {
+    const { limit, offset, filter } = this
+
+    this.call = this.request.send(
+      buildURL(`account-tags`, {
+        limit,
+        offset,
+        filter
+      }),
+      'GET',
+      undefined,
+      token,
+      this
+    )
+
+    return this.call
+  }
+
+  Get(accountTagId, token = null) {
+    return this.request.send(
+      `account-tags/${accountTagId}`,
+      'GET',
+      undefined,
+      token
+    )
+  }
+
+  Update(accountTagId, body, token = null) {
+    return this.request.send(`account-tags/${accountTagId}`, 'PUT', body, token)
+  }
+
+  Delete(accountTagId, token = null) {
+    return this.request.send(
+      `account-tags/${accountTagId}`,
+      'DELETE',
+      undefined,
+      token
+    )
+  }
+}
+
+export default AccountTagsEndpoint

--- a/src/endpoints/accounts.js
+++ b/src/endpoints/accounts.js
@@ -12,13 +12,14 @@ class AccountsEndpoint extends CRUDExtend {
   }
 
   All(token = null, headers = {}) {
-    const { limit, offset, filter } = this
+    const { limit, offset, filter, includes } = this
 
     this.call = this.request.send(
       buildURL(this.endpoint, {
         limit,
         offset,
-        filter
+        filter,
+        includes
       }),
       'GET',
       undefined,

--- a/src/endpoints/accounts.js
+++ b/src/endpoints/accounts.js
@@ -30,6 +30,22 @@ class AccountsEndpoint extends CRUDExtend {
 
     return this.call
   }
+
+  AddAccountTags(accountId, requestBody) {
+    return this.request.send(
+      `${this.endpoint}/${accountId}/relationships/account-tags`,
+      'POST',
+      requestBody
+    )
+  }
+
+  DeleteAccountTags(accountId, requestBody) {
+    return this.request.send(
+      `${this.endpoint}/${accountId}/relationships/account-tags`,
+      'DELETE',
+      requestBody
+    )
+  }
 }
 
 export default AccountsEndpoint

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -71,6 +71,7 @@ import { SubscriptionInvoicesEndpoint } from './types/subscription-invoices'
 import { CustomRelationshipsEndpoint } from './types/custom-relationships'
 import { MultiLocationInventoriesEndpoint } from './types/multi-location-inventories'
 import { CustomApiRolePoliciesEndpoint } from './types/custom-api-role-policies'
+import { AccountTagsEndpoint } from './types/account-tags'
 
 export * from './types/config'
 export * from './types/storage'
@@ -154,6 +155,7 @@ export * from './types/custom-relationships'
 export * from './types/pcm-custom-relationship'
 export * from './types/mli-locations'
 export * from './types/multi-location-inventories'
+export * from './types/account-tags'
 
 // UMD
 export as namespace elasticpath
@@ -226,6 +228,7 @@ export class ElasticPath {
   SubscriptionInvoices: SubscriptionInvoicesEndpoint
   CustomRelationships: CustomRelationshipsEndpoint
   MultiLocationInventories: MultiLocationInventoriesEndpoint
+  AccountTags: AccountTagsEndpoint
 
   Cart(id?: string): CartEndpoint // This optional cart id is super worrying when using the SDK in a node server :/
   constructor(config: Config)

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,7 @@ import SubscriptionProrationPoliciesEndpoint from './endpoints/subscription-pror
 import SubscriptionInvoicesEndpoint from './endpoints/subscription-invoices'
 import CustomRelationshipsEndpoint from './endpoints/custom-relationships'
 import MultiLocationInventoriesEndpoint from './endpoints/multi-location-inventories'
+import AccountTagsEndpoint from './endpoints/account-tags'
 
 import {
   cartIdentifier,
@@ -154,6 +155,7 @@ export default class ElasticPath {
     this.SubscriptionInvoices = new SubscriptionInvoicesEndpoint(config)
     this.CustomRelationships = new CustomRelationshipsEndpoint(config)
     this.MultiLocationInventories = new MultiLocationInventoriesEndpoint(config)
+    this.AccountTags = new AccountTagsEndpoint(config)
   }
 
   // Expose `Cart` class on ElasticPath class

--- a/src/types/account-tags.d.ts
+++ b/src/types/account-tags.d.ts
@@ -1,0 +1,54 @@
+import {
+  CrudQueryableResource,
+  Identifiable,
+  Resource,
+  ResourcePage
+} from './core'
+
+export interface AccountTagBase {
+  type: string
+  name: string
+  description: string
+}
+
+export interface AccountTagMeta {
+  timestamps: {
+    created_at: string
+    updated_at: string
+  }
+}
+
+export interface AccountTag extends Identifiable, AccountTagBase {
+  meta: AccountTagMeta
+}
+
+export interface AccountTagFilter {
+  like?: {
+    name?: string
+  }
+}
+
+export interface AccountTagsEndpoint
+  extends CrudQueryableResource<
+    AccountTag,
+    AccountTagBase,
+    AccountTagBase,
+    AccountTagFilter,
+    never,
+    never
+  > {
+  endpoint: 'account-tags'
+
+  Create(body: AccountTagBase): Promise<Resource<AccountTag>>
+
+  All(token?: string, headers?): Promise<ResourcePage<AccountTag>>
+
+  Get(accountTagId: string, token?: string): Promise<Resource<AccountTag>>
+
+  Update(
+    accountTagId: string,
+    body: AccountTagBase
+  ): Promise<Resource<AccountTag>>
+
+  Delete(accountTagId: string): Promise<{}>
+}

--- a/src/types/accounts.d.ts
+++ b/src/types/accounts.d.ts
@@ -5,8 +5,10 @@ import {
   CrudQueryableResource,
   Identifiable,
   Resource,
-  ResourceList,
+  ResourcePage
 } from './core'
+import { AccountTag } from './account-tags'
+import { RelationshipToMany } from './core'
 
 /**
  * The Account object Interface
@@ -34,6 +36,7 @@ export interface Account extends AccountBase, Identifiable {
         }
       }
     ]
+    account_tags: RelationshipToMany<'account_tag'>
   }
 }
 
@@ -44,8 +47,10 @@ export interface AccountBase {
   registration_id?: string
   parent_id?: string
   external_ref?: string
+  relationships?: {
+    account_tags: RelationshipToMany<'account_tag'>
+  }
 }
-
 
 /**
  * filter for accounts
@@ -62,6 +67,7 @@ export interface AccountFilter {
     legal_name?: string
     registration_id?: string
     external_ref?: string
+    account_tags?: string[]
   }
 }
 export interface AccountUpdateBody extends Partial<AccountBase> {}
@@ -77,7 +83,7 @@ export interface AccountEndpoint
       AccountUpdateBody,
       AccountFilter,
       never,
-      never
+      'account_tags'
     >,
     'All' | 'Create' | 'Get' | 'Update'
   > {
@@ -89,7 +95,17 @@ export interface AccountEndpoint
    * @param token - The Bearer token to grant access to the API.
    * @param headers
    */
-  All(token?: string, headers?): Promise<ResourceList<Account>>
+  All(
+    token?: string,
+    headers?: {}
+  ): Promise<
+    ResourcePage<
+      Account,
+      {
+        account_tags: AccountTag[]
+      }
+    >
+  >
 
   /**
    * Get an Account by reference
@@ -103,8 +119,11 @@ export interface AccountEndpoint
    */
   Create(body: AccountBase): Promise<Resource<Account>>
 
- /**
+  /**
    * Update an Account
    */
-  Update(accountId: string, body: Partial<AccountBase>): Promise<Resource<Account>>
+  Update(
+    accountId: string,
+    body: Partial<AccountBase>
+  ): Promise<Resource<Account>>
 }

--- a/src/types/accounts.d.ts
+++ b/src/types/accounts.d.ts
@@ -126,4 +126,26 @@ export interface AccountEndpoint
     accountId: string,
     body: Partial<AccountBase>
   ): Promise<Resource<Account>>
+
+  /**
+   * Add account tags to an Account
+   */
+  AddAccountTags(
+    accountId: string,
+    requestBody: Array<{
+      id: string
+      type: 'account_tag'
+    }>
+  ): Promise<void>
+
+  /**
+   * Delete account tags from an Account
+   */
+  DeleteAccountTags(
+    accountId: string,
+    requestBody: Array<{
+      id: string
+      type: 'account_tag'
+    }>
+  ): Promise<void>
 }


### PR DESCRIPTION
## Type

* ### Feature
  Implements a new feature

## Description
- add account tags endpoints
- update accounts endpoints to support account tags in accounts
   - add / delete account tags from an account
   - support includes in the param

## Dependencies
- [[MT-21428] Account tags](https://gitlab.elasticpath.com/commerce-cloud/commerce-manager/-/merge_requests/3253)
