### PR TITLE
feat: add GetNodesByIds method to hierarchies endpoint

### DIFF
--- a/src/endpoints/hierarchies.js
+++ b/src/endpoints/hierarchies.js
@@ -37,6 +37,42 @@ class HierarchiesEndpoint extends CRUDExtend {
       token
     )
   }
+
+  GetNodesByIds(nodeIds, token = null) {
+    if (!nodeIds || nodeIds.length === 0) {
+      return Promise.resolve({
+        data: [],
+        links: {},
+        meta: {
+          page: {
+            current: 1,
+            limit: 100,
+            offset: 0,
+            total: 0
+          },
+          results: {
+            total: 0
+          }
+        }
+      })
+    }
+
+    const filter = {
+      or: nodeIds.map(id => ({
+        eq: { id }
+      }))
+    }
+
+    return this.request.send(
+      buildURL('hierarchies/nodes', {
+        filter,
+        include_hierarchies: true
+      }),
+      'GET',
+      undefined,
+      token
+    )
+  }
 }
 
 export default HierarchiesEndpoint

--- a/src/types/hierarchies.d.ts
+++ b/src/types/hierarchies.d.ts
@@ -49,7 +49,7 @@ export interface DuplicateHierarchyBody {
   }
 }
 
-export type DuplicateHierarchyJob  = Identifiable & PcmJobBase
+export type DuplicateHierarchyJob = Identifiable & PcmJobBase
 
 export interface HierarchyFilter {
   // TODO
@@ -82,6 +82,7 @@ export interface HierarchiesEndpoint
     body: DuplicateHierarchyBody,
     token?: string
   ): Promise<Resource<DuplicateHierarchyJob>>
+  GetNodesByIds(nodeIds: string[], token?: string): Promise<ResourcePage<Node>>
   Limit(value: number): HierarchiesEndpoint
   Offset(value: number): HierarchiesEndpoint
 }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -90,7 +90,8 @@ export function parseJSON(response) {
   })
 }
 
-function buildQueryParams({ includes, sort, limit, offset, filter, useTemplateSlugs, total_method }) {
+function buildQueryParams(params) {
+  const { includes, sort, limit, offset, filter, useTemplateSlugs, total_method, ...additionalParams } = params
   const query = {}
 
   if (includes) {
@@ -121,6 +122,13 @@ function buildQueryParams({ includes, sort, limit, offset, filter, useTemplateSl
     query.total_method = total_method
   }
 
+  // Add any additional parameters with URI encoding
+  Object.keys(additionalParams).forEach(key => {
+    if (additionalParams[key] !== undefined && additionalParams[key] !== null) {
+      query[key] = additionalParams[key]
+    }
+  })
+
   return Object.keys(query)
     .map(k => formatQueryString(k, query[k]))
     .join('&')
@@ -133,18 +141,17 @@ export function formatQueryParams(query) {
 }
 
 export function buildURL(endpoint, params) {
-  if (
-    params.includes ||
-    params.sort ||
-    (params.limit !== undefined && params.limit !== null) ||
-    params.offset ||
-    params.filter ||
-    params.useTemplateSlugs ||
-    params.total_method
-  ) {
+  // Check if any params are provided
+  const hasParams = Object.keys(params).some(key => 
+    params[key] !== undefined && params[key] !== null
+  )
+  
+  if (hasParams) {
     const paramsString = buildQueryParams(params)
-
-    return `${endpoint}?${paramsString}`
+    
+    if (paramsString) {
+      return `${endpoint}?${paramsString}`
+    }
   }
   return endpoint
 }


### PR DESCRIPTION
## Type

* ### Feature
  Implements a new feature

## Description
  - Add GetNodesByIds method to fetch multiple nodes by their IDs
  - Update buildURL helper to support additional query parameters
  - Support include_hierarchies and other custom parameters in query strings

## Dependencies

