### PR TITLE
fix: add missing types for release endpoint

### DIFF
--- a/src/types/catalogs-releases.d.ts
+++ b/src/types/catalogs-releases.d.ts
@@ -48,6 +48,17 @@ export interface CatalogsReleasesEndpoint {
     token?: string
   }): Promise<Resource<ReleaseBase>>
 
+  Delete(options: {
+    catalogId: string
+    releaseId: string
+    token?: string
+  }): Promise<{}>
+
+  DeleteAll(options: {
+    catalogId: string
+    token?: string
+  }): Promise<{}>
+
   Limit(value: number): CatalogsReleasesEndpoint
 
   Offset(value: number): CatalogsReleasesEndpoint


### PR DESCRIPTION
## Type

* ### Fix
  Fixes a bug

## Description

Add missing types for the new delete and deleteAll functions of the catalog release endpoint

## Notes

Missed this in my last PR. (been a while since having to deal with types separately not auto generating)
