### PR TITLE
feat: shopper/admin attributes, bundle min/max, catalog rule validation, pricebook segmentation

### DIFF
--- a/src/endpoints/catalogs.js
+++ b/src/endpoints/catalogs.js
@@ -348,6 +348,20 @@ class Rules extends CRUDExtend {
       token
     )
   }
+
+  Validate(body, token = null) {
+    const { limit, offset } = this
+
+    return this.request.send(
+      buildURL(`catalogs/${this.endpoint}/validate`, {
+        limit,
+        offset
+      }),
+      'POST',
+      body,
+      token
+    )
+  }
 }
 
 class CatalogsEndpoint extends CRUDExtend {

--- a/src/endpoints/pcm.js
+++ b/src/endpoints/pcm.js
@@ -64,13 +64,18 @@ class PCMEndpoint extends CRUDExtend {
     return this.request.send(`${this.endpoint}/detach_nodes`, 'POST', body)
   }
 
-  ExportProducts(filter, useTemplateSlugs) {
+  ExportProducts(filter, useTemplateSlugs, columns) {
+    const body = columns
+      ? { data: { type: 'product', attributes: { columns } } }
+      : undefined
+
     return this.request.send(
         buildURL(`${this.endpoint}/export`, {
           filter,
           useTemplateSlugs
         }),
-        'POST'
+        'POST',
+        body
     )
   }
 }

--- a/src/types/catalogs-products.d.ts
+++ b/src/types/catalogs-products.d.ts
@@ -9,6 +9,44 @@ export interface CatalogsProductVariation
   options: Omit<Option, 'modifiers'>[]
 }
 
+export interface PriceTier {
+  minimum_quantity: number
+  amount: {
+    [currency: string]: {
+      amount: number
+      includes_tax: boolean
+    }
+  }
+}
+
+export interface AvailablePrice {
+  pricebook_id: string
+  shopper_attributes?: { [key: string]: string }
+  sale_id?: string
+  sale_expires?: string
+  price?: {
+    [currency: string]: {
+      amount: number
+      includes_tax: boolean
+    }
+  }
+  tiers?: { [tier: string]: PriceTier }
+}
+
+export interface AlternativePrice extends AvailablePrice {
+  name: string
+  display_price?: {
+    without_tax?: FormattedPrice
+    with_tax?: FormattedPrice
+  }
+  original_price?: {
+    [currency: string]: {
+      amount: number
+      includes_tax: boolean
+    }
+  }
+}
+
 export interface ProductResponse extends Identifiable {
   type: 'product'
   attributes: {
@@ -38,6 +76,9 @@ export interface ProductResponse extends Identifiable {
     weight: string
     manufacturer_part_num?: string
     extensions?: Extensions
+    available_prices?: AvailablePrice[]
+    alternative_prices?: { [name: string]: AlternativePrice }
+    available_pricebook_ids?: string[]
   }
   meta: {
     catalog_id?: string
@@ -76,6 +117,7 @@ export interface ProductResponse extends Identifiable {
           }
         }
         pricebook_id: string
+        alternative_prices?: { [name: string]: AlternativePrice }
       }
     }
   }

--- a/src/types/catalogs-releases.d.ts
+++ b/src/types/catalogs-releases.d.ts
@@ -22,6 +22,14 @@ export interface ReleaseBodyBase {
   export_full_delta?: boolean
 }
 
+export type ReleaseIndexingStatus = 'succeeded' | 'failed'
+
+export interface ReleaseIndexingCompleteData {
+  data: {
+    status: ReleaseIndexingStatus
+  }
+}
+
 export interface CatalogsReleasesEndpoint {
   endpoint: 'releases'
 

--- a/src/types/catalogs-rules.d.ts
+++ b/src/types/catalogs-rules.d.ts
@@ -4,7 +4,9 @@
  */
 import {
   Identifiable,
-  CrudQueryableResource
+  CrudQueryableResource,
+  Resource,
+  ResourcePage
 } from './core'
 
   /**
@@ -21,6 +23,7 @@ export interface RuleBase {
     customer_ids?: string[]
     channels?: string[]
     tags?: string[]
+    pricebook_ids?: string[]
     schedules?: {valid_from: string, valid_to: string}[]
   }
 }
@@ -33,8 +36,19 @@ export interface Rule extends Identifiable, RuleBase  {
 
 // Do Not have any relationships yet //TODO
 
+export interface RuleFilterAttributes {
+  id?: string
+  catalog_id?: string
+  account_ids?: string
+  customer_ids?: string
+  channels?: string
+  tags?: string
+  pricebook_ids?: string
+}
+
 export interface RuleFilter {
-// TODO
+  eq?: RuleFilterAttributes
+  in?: Pick<RuleFilterAttributes, 'pricebook_ids'>
 }
 
 type RuleSort = // TODO
@@ -47,10 +61,53 @@ export interface RuleUpdateBody extends RuleBase {
   id: string
 }
 
+export type RuleValidationMatchType =
+  | 'filter'
+  | 'similarity'
+  | 'conflict'
+  | 'resolve_for_shopper'
+
+export interface RuleValidationCriteria {
+  channels?: string[]
+  tags?: string[]
+  account_ids?: string[]
+  account_tag_ids?: string[]
+  customer_ids?: string[]
+}
+
+export interface CatalogRuleValidatorRequest {
+  data: {
+    type: 'catalog_rule_validator'
+    match_type: RuleValidationMatchType
+    catalog_id?: string
+    pricebook_ids?: string[]
+    schedules?: { valid_from: string; valid_to: string }[]
+    attributes?: RuleValidationCriteria
+  }
+}
+
+export interface RuleMeta {
+  similarity_score?: number
+  active?: boolean
+  resolved_for_shopper?: boolean
+  release_id?: string
+}
+
+export interface ValidatedRule extends Rule {
+  meta?: RuleMeta
+}
+
+export type ValidateRulesResponse = ResourcePage<ValidatedRule>
+
 export interface CatalogsRulesEndpoint
 extends CrudQueryableResource<Rule, RuleBase, RuleUpdateBody, RuleFilter, RuleSort, RuleInclude> {
   endpoint: 'rules'
   id: string
+
+  /**
+   * Validate Catalog Rules
+   * @param body - validation request describing the match_type and rule criteria.
+   * @param token - optional customer token.
+   */
+  Validate(body: CatalogRuleValidatorRequest, token?: string): Promise<ValidateRulesResponse>
 }
-
-

--- a/src/types/pcm.d.ts
+++ b/src/types/pcm.d.ts
@@ -41,6 +41,8 @@ export interface PcmProductBase extends PcmProductRelationships {
     components?: ProductComponents
     custom_inputs?: CustomInputs
     tags?: string[]
+    admin_attributes?: { [key: string]: string }
+    shopper_attributes?: { [key: string]: string }
   }
 }
 

--- a/src/types/pcm.d.ts
+++ b/src/types/pcm.d.ts
@@ -259,7 +259,19 @@ export interface PcmProductsEndpoint
   /**
    * Export products
    * @param filter - products filters
+   * @param useTemplateSlugs - use template slugs instead of template IDs
+   * @param columns - select which columns to include in the exported CSV. Supports
+   *  individual keys (e.g. `admin_attributes.cost_of_goods`) and wildcards
+   *  (e.g. `admin_attributes.*`).
    * @constructor
    */
-  ExportProducts(filter?: PcmProductFilter, useTemplateSlugs?: boolean): Promise<Resource<PcmJob>>
+  ExportProducts(
+    filter?: PcmProductFilter,
+    useTemplateSlugs?: boolean,
+    columns?: PcmProductExportColumns
+  ): Promise<Resource<PcmJob>>
+}
+
+export interface PcmProductExportColumns {
+  include: string[]
 }

--- a/src/types/pcm.d.ts
+++ b/src/types/pcm.d.ts
@@ -88,6 +88,8 @@ export interface ProductComponentOption {
   id: string
   quantity: number
   type: string
+  min?: number | null
+  max?: number | null
   sort_order?: number | null
   default?: boolean
   meta: {


### PR DESCRIPTION
Closes #90

## Summary

Brings the legacy SDK in line with recent additions to the upstream PIM (`pim.yaml`) and shopper Catalog View (`catalog_view.yaml`) OpenAPI specs. All changes are additive — no breaking changes.

### From `pim.yaml` (admin / PXM)

- **`shopper_attributes` / `admin_attributes` on products** — adds the two `{ [key: string]: string }` maps to `PcmProductBase.attributes` (the equivalent fields are already on `HierarchyBase` and `NodeBase`, so this rounds out the trio).
- **Per-option `min` / `max` on bundle component options** — adds `min` and `max` to `ProductComponentOption` (component-level `min`/`max` already exists on `ProductComponents`).
- **Product export `columns.include`** — adds an optional third argument to `ExportProducts(filter, useTemplateSlugs, columns)` and threads `{ data: { type: 'product', attributes: { columns } } }` through as the request body. Supports individual keys (`admin_attributes.cost_of_goods`) and wildcards (`admin_attributes.*`).

### From `catalog_view.yaml` (shopper / catalog)

- **`Validate` on `Rules`** — new `POST /catalogs/rules/validate` method on the `CatalogsRulesEndpoint`. Adds `CatalogRuleValidatorRequest` (with `match_type` of `filter` | `similarity` | `conflict` | `resolve_for_shopper`), `RuleMeta` (`similarity_score`, `active`, `resolved_for_shopper`, `release_id`), `ValidatedRule`, and `ValidateRulesResponse`.
- **`pricebook_ids` on `RuleFilter`** — populates the previously-stub `RuleFilter` interface with `eq` and `in` operators against `id`, `catalog_id`, `account_ids`, `customer_ids`, `channels`, `tags` and the new `pricebook_ids`. Also adds `pricebook_ids?: string[]` on `RuleBase.attributes`.
- **Pricebook segmentation product fields** — adds `available_prices`, `alternative_prices` and `available_pricebook_ids` on `ProductResponse.attributes`. Component product metadata also gains `alternative_prices`. New `AvailablePrice`, `AlternativePrice` and `PriceTier` types.
- **`ReleaseIndexingCompleteData`** — new type for the indexing-complete payload (`{ data: { status: 'succeeded' | 'failed' } }`).

### Out of scope

- The `EP-Pricebook-IDs-Of-Available-Prices-To-Show` request header isn't threaded through the relevant `Catalog`/`Catalogs.Products` methods. The request factory already supports `additionalHeaders` so this could be done as a follow-up; threading it through every method is a larger API surface change worth its own PR.

## Test plan

- [x] `yarn lint` clean
- [x] `yarn rollup` builds clean (existing `CodeFileHref` re-export warning is pre-existing on `main`)
- [ ] `yarn test` — pre-existing environment issue on `main` (`chai` module not linked under current Node version) blocks the suite; not introduced here
- [ ] Reviewer: spot-check the new types compile against a downstream consumer