### PR TITLE
feat: adopt standard-user/shopper-roles in custom-api-role-policies

### DIFF
--- a/src/endpoints/custom-api-role-policies.js
+++ b/src/endpoints/custom-api-role-policies.js
@@ -11,8 +11,8 @@ class CustomApiRolePoliciesEndpoint extends CRUDExtend {
 
   CreateCustomApiRolePolicy(body) {
     return this.request.send(
-      `${this.endpoint}/custom-api-role-policies`, 
-      'POST', 
+      `${this.endpoint}/custom-api-role-policies`,
+      'POST',
       body
     )
   }
@@ -25,11 +25,13 @@ class CustomApiRolePoliciesEndpoint extends CRUDExtend {
     )
   }
 
-  GetCustomApiRolePolicies({ customApiId }) {
+  GetCustomApiRolePolicies({ customApiId, include } = {}) {
     const { limit, offset, sort } = this
 
     return this.request.send(
-      buildURL(`${this.endpoint}/custom-api-role-policies?filter=eq(custom_api_id,${customApiId})`, {
+      buildURL(`${this.endpoint}/custom-api-role-policies`, {
+        filter: { eq: { custom_api_id: customApiId } },
+        ...(include === 'role' && { include }),
         limit,
         offset,
         sort
@@ -38,9 +40,16 @@ class CustomApiRolePoliciesEndpoint extends CRUDExtend {
     )
   }
 
-  GetBuiltInRoles() {
+  GetStandardUserRoles() {
     return this.request.send(
-      `${this.endpoint}/built-in-roles`,
+      `${this.endpoint}/standard-user-roles`,
+      'GET'
+    )
+  }
+
+  GetStandardShopperRoles() {
+    return this.request.send(
+      `${this.endpoint}/standard-shopper-roles`,
       'GET'
     )
   }

--- a/src/types/custom-api-role-policies.ts
+++ b/src/types/custom-api-role-policies.ts
@@ -1,14 +1,23 @@
-import { Resource } from './core'
+import { Resource, ResourceList } from './core'
 
-export interface BuiltInRolePolicy {
+export interface StandardUserRole {
   id: string
-  type: 'built_in_role'
-  links: {
-    self: string
-  }
+  type: 'standard_user_role'
+  links: { self: string }
   name: string
-  cm_user_assignable: boolean
 }
+
+export interface StandardShopperRole {
+  id: string
+  type: 'standard_shopper_role'
+  links: { self: string }
+  name: string
+}
+
+export type StandardRole = StandardUserRole | StandardShopperRole
+export type StandardRoleType = StandardRole['type']
+
+export type IncludedRole = Omit<StandardRole, 'links'>
 
 export interface CustomApiRolePolicyBase {
   data: {
@@ -29,18 +38,8 @@ export interface CustomApiRolePolicyRequestBody {
   update: boolean
   delete: boolean
   relationships: {
-    custom_api: {
-      data: {
-        type: 'custom_api'
-        id: string
-      }
-    }
-    role: {
-      data: {
-        type: 'built_in_role'
-        id: string
-      }
-    }
+    custom_api: { data: { type: 'custom_api'; id: string } }
+    role: { data: { type: StandardRoleType; id: string } }
   }
 }
 
@@ -48,22 +47,10 @@ export interface CustomApiRolePolicy {
   id: string
   type: 'custom_api_role_policy'
   relationships: {
-    custom_api: {
-      data: {
-        type: 'custom_api'
-        id: string
-      }
-    }
-    role: {
-      data: {
-        type: 'built_in_role'
-        id: string
-      }
-    }
+    custom_api: { data: { type: 'custom_api'; id: string } }
+    role: { data: { type: StandardRoleType; id: string } }
   }
-  links: {
-    self: string
-  }
+  links: { self: string }
   meta: {
     timestamps: {
       created_at: string
@@ -75,6 +62,14 @@ export interface CustomApiRolePolicy {
   read: boolean
   update: boolean
   delete: boolean
+}
+
+export interface CustomApiRolePoliciesIncluded {
+  role: IncludedRole[]
+}
+
+export interface CustomApiRolePoliciesResponse extends ResourceList<CustomApiRolePolicy> {
+  included?: CustomApiRolePoliciesIncluded
 }
 
 export interface CustomApiRolePoliciesEndpoint {
@@ -91,9 +86,12 @@ export interface CustomApiRolePoliciesEndpoint {
 
   GetCustomApiRolePolicies(args: {
     customApiId: string
-  }): Promise<Resource<Array<CustomApiRolePolicy>>>
+    include?: 'role'
+  }): Promise<CustomApiRolePoliciesResponse>
 
-  GetBuiltInRoles(): Promise<Resource<Array<BuiltInRolePolicy>>>
+  GetStandardUserRoles(): Promise<ResourceList<StandardUserRole>>
+
+  GetStandardShopperRoles(): Promise<ResourceList<StandardShopperRole>>
 
   DeleteCustomApiRolePolicy(policyId: string): Promise<void>
 }


### PR DESCRIPTION
## Type

* ### Feature
  Implements a new feature

## Description

- Removed `GetBuiltInRoles` and `BuiltInRolePolicy`. Replace with `GetStandardUserRoles` + `GetStandardShopperRoles`. `CustomApiRolePolicy` now uses `standard_user_role` / `standard_shopper_role` on relationships.role.data.type (was built_in_role).
- `GetCustomApiRolePolicies` accepts an `include: 'role'` argument and its return type changes from Promise<Resource<Array<CustomApiRolePolicy>>> to Promise<CustomApiRolePoliciesResponse>, which adds optional `included.role` inline. 

## Dependencies
[[MT-23086] Adopt new custom-api role policies endpoints](https://gitlab.elasticpath.com/commerce-cloud/commerce-manager/-/merge_requests/3721)
