### PR TITLE
[MT-23080] feat: add optional id to rule-promotion Action

### DIFF
--- a/src/types/rule-promotions.ts
+++ b/src/types/rule-promotions.ts
@@ -36,6 +36,7 @@ export interface ActionCondition {
 }
 
 export interface Action {
+  id?: string
   strategy: string
   args: any[]
   limitations?: ActionLimitation


### PR DESCRIPTION
## Type

* ### Feature
  Implements a new feature

## Description
Backend (promotions.svc!895) now assigns a UUID to each action on a rule promotion and matches actions by id on update. Adding an optional id field lets consumers round-trip it without losing type safety.

The field is intentionally optional: it is absent on create requests and on legacy promotion responses prior to backend backfill.

## Dependencies
[[MT-23080] Include action UUID on update in promotion builder](https://gitlab.elasticpath.com/commerce-cloud/commerce-manager/-/merge_requests/3733)